### PR TITLE
매일 오전 8시에 스크래퍼 테스트 하도록 수정

### DIFF
--- a/.github/workflows/scraping_test.yml
+++ b/.github/workflows/scraping_test.yml
@@ -1,10 +1,8 @@
 name: Test scraper
 
 on:
-  push:
-    branches: ["feature/ci"]
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 23 * * *"
 
 jobs:
   run:

--- a/.github/workflows/scraping_test.yml
+++ b/.github/workflows/scraping_test.yml
@@ -1,6 +1,8 @@
 name: Test scraper
 
 on:
+  push:
+    branches: ["feature/ci"]
   schedule:
     - cron: "0 3 * * *"
 

--- a/.github/workflows/scraping_test.yml
+++ b/.github/workflows/scraping_test.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/test/scraper_test.py
+++ b/test/scraper_test.py
@@ -1,7 +1,8 @@
 import os, sys
 from github import Github
 
-sys.path.append(os.path.abspath('../src'))
+BASE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, BASE + '/src')
 import scraper
 
 GIT_ACCESS_TOKEN = os.environ["GIT_ACCESS_TOKEN"]

--- a/test/scraper_test.py
+++ b/test/scraper_test.py
@@ -4,6 +4,7 @@ from github import Github
 BASE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, BASE + '/src')
 import scraper
+from notice import notice
 
 GIT_ACCESS_TOKEN = os.environ["GIT_ACCESS_TOKEN"]
 REPO_URL = "jja08111/HansungNotificationServer"
@@ -12,12 +13,20 @@ def createIssue(body: str):
     github = Github(GIT_ACCESS_TOKEN)
     github.get_repo(REPO_URL).create_issue("공지 스크래핑 실패", body=body, labels=["bug"])
 
+def printResult(result: list[notice]):
+    print('-------Result-------')
+    for notice in result:
+        print(notice.id)
+    print('--------------------')
+
 def main():
     '''스크래퍼가 작동하지 않는다면 HansungNotificationServer에 이슈를 등록한다.'''
     try:
         result = scraper.scrapeNotices()
         if (result.__len__() < 1):
             raise Exception("스크래핑한 공지가 0개입니다.")
+
+        printResult(result)
     except BaseException as e:
         print('Failed to scrap notices.')
         createIssue(str(e))

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,1 +1,2 @@
 PyGithub==1.55
+bs4


### PR DESCRIPTION
매일 8시에 스크래퍼를 테스트 하도록 하며 실패시 Issue에 글을 작성하도록 하였다. 이로써 관리자 휴대폰에서 알림을 놓쳐도 깃허브에서 실패 기록을 확인할 수 있게 되었다.